### PR TITLE
Do not override if env exists

### DIFF
--- a/lib/secrets/index.js
+++ b/lib/secrets/index.js
@@ -36,7 +36,7 @@ function addSecretToEnv(secret) {
   }
 
   for (const [key, value] of Object.entries(data)) {
-    process.env[key] = value;
+    process.env[key] ||= value;
   }
 }
 


### PR DESCRIPTION
If environment variable exists, do not override it.
This way we can use different values in Docker env.

Figaro (gem for ruby env config) does the same thing